### PR TITLE
fix: update session retrieval

### DIFF
--- a/agent.py
+++ b/agent.py
@@ -45,7 +45,7 @@ def run_multimodal_agent(ctx: JobContext, participant: rtc.RemoteParticipant):
     agent = MultimodalAgent(model=model)
     agent.start(ctx.room, participant)
 
-    session = model.sessions[0]
+    session = next(iter(model.sessions), None) 
     session.conversation.item.create(
         llm.ChatMessage(
             role="assistant",


### PR DESCRIPTION
I followed the example in the docs and cloned a starter template

`lk app create --template multimodal-agent-python
`

then I run it and connect through the front end, I get the following error:

```
python agent.py dev
...
2025-01-01 21:50:32,279 - ERROR livekit.agents - unhandled exception while running the job task
Traceback (most recent call last):
  File "/Users/zt9/code/livekit/agentexpt/agent.py", line 29, in entrypoint
    run_multimodal_agent(ctx, participant)
  File "/Users/zt9/code/livekit/agentexpt/agent.py", line 48, in run_multimodal_agent
    session = model.sessions[0]
TypeError: 'WeakSet' object is not subscriptable {"pid": 61183, "job_id": "AJ_g2n6EK7YkJdd"}

```

Since sessions are now maintained as a WeakSet instead of a list, update session retrieval from indexing to iterator usage. 

Before: `session = model.sessions[0]`
After: `session = next(iter(model.sessions), None)`