### PR TITLE
Restrict agents package requirements to <1.0

### DIFF
--- a/requirements.txt
+++ b/requirements.txt
@@ -1,4 +1,4 @@
 livekit>=0.19.1
-livekit-agents>=0.12.11
-livekit-plugins-openai>=0.10.17
+livekit-agents>=0.12.11,<1.0.0
+livekit-plugins-openai>=0.10.17,<1.0.0
 python-dotenv~=1.0


### PR DESCRIPTION
Updating the package requirements to ensure that we only pull versions prior to v1.0.0 in order to maintain compatibility with the implementation in this example.